### PR TITLE
ci: ensure webapp build is tested with wasm dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,23 @@ jobs:
       - name: Build Rust
         run: make rust-build
 
+      - name: Build wasm
+        run: make wasm-build
+
       - name: Test Rust
         run: make rust-test
+
+      - name: Upload WASM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-build
+          path: webapp/wasm/
+          retention-days: 1
 
   test-webapp:
     name: Test Webapp
     runs-on: ubuntu-24.04
+    needs: test-rust
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -76,8 +87,17 @@ jobs:
       - name: Install webapp dependencies
         run: make webapp-install
 
+      - name: Download WASM artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-build
+          path: webapp/wasm/
+
       - name: Check formatting
         run: make webapp-fmt-check
 
       - name: Lint webapp
         run: make webapp-lint
+
+      - name: Build webapp
+        run: make webapp-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Cache Cargo registry
         uses: actions/cache@v4
@@ -45,11 +46,11 @@ jobs:
       - name: Build Rust
         run: make rust-build
 
-      - name: Build wasm
-        run: make wasm-build
-
       - name: Test Rust
         run: make rust-test
+
+      - name: Build wasm
+        run: make wasm-build
 
       - name: Upload WASM artifacts
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ rust-lint:
 # Install dependencies
 rust-install:
 	cargo fetch
+	cargo install wasm-pack --version 0.13.1
 
 # Build all Rust crates (debug)
 rust-build:

--- a/webapp/src/components/layout/header.tsx
+++ b/webapp/src/components/layout/header.tsx
@@ -6,7 +6,6 @@ import {
   HStack,
   IconButton,
   Spacer,
-  Text,
   Tooltip,
   useColorMode,
 } from "@chakra-ui/react";


### PR DESCRIPTION
- Add needs: test-rust to test-webapp job to enforce dependency ordering
- Upload WASM artifacts from test-rust job after build completes
- Download WASM artifacts in test-webapp before running webapp build
- Add make webapp-build step to test-webapp job

This ensures webapp build failures are caught in CI and prevents silent failures from missing WASM modules. Previously, test-webapp ran in parallel and never validated that webapp-build succeeded with the built WASM artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)