### PR TITLE
Add support for json <-> xml conversion in cli and webapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.2.0] - 2025-12-30
+
+### cli
+
+- feat: add support for bidirectional XML ⇄ JSON format conversion.
+
+### webapp
+
+- feat: add XML ⇄ JSON format conversion tool.
+- fix: fix styling issues in webapp for better user experience.
+
 ## [v1.1.2] - 2025-12-26
 
 ### webapp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "strapd"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "clap",
  "copypasta",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "strapd-core"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -895,7 +895,7 @@ dependencies = [
 
 [[package]]
 name = "strapd-wasm"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "getrandom",
  "strapd-core",

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It's primarily CLI-focused, but also includes a webapp interface for those who p
 - **Identifiers**: UUIDs (v4, v7), ULIDs
 - **Encoding**: Base64, URL, Hex
 - **Data Formatting**: JSON, YAML, XML, SQL (beautify, minify, sort)
-- **Format Conversion**: YAML ⇄ JSON
+- **Format Conversion**: YAML ⇄ JSON, XML ⇄ JSON
 - **Security**: Hash (MD5, SHA-1, SHA-256, SHA-512), HMAC (SHA-256, SHA-512)
 - **Random**: numbers, strings
 - **Date/Time**: timestamps

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strapd"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/cli/src/args/data_formats.rs
+++ b/crates/cli/src/args/data_formats.rs
@@ -42,6 +42,10 @@ pub enum JsonOperation {
 
         #[arg(short = 't', long = "to")]
         to: String,
+
+        /// Optional root element name for XML conversion (default: "root")
+        #[arg(long = "root")]
+        root: Option<String>,
     },
 }
 
@@ -62,6 +66,14 @@ pub enum XmlOperation {
     Minify {
         /// The string to convert (if not provided, reads from stdin)
         input: Option<String>,
+    },
+    #[command(aliases = ["transform"])]
+    Convert {
+        /// The string to convert (if not provided, reads from stdin)
+        input: Option<String>,
+
+        #[arg(short = 't', long = "to")]
+        to: String,
     },
 }
 

--- a/crates/cli/src/handlers/data_formats_handler.rs
+++ b/crates/cli/src/handlers/data_formats_handler.rs
@@ -31,14 +31,18 @@ pub fn handle_json(operation: &JsonOperation) -> CommandResult {
                 Err(e) => error_result(e),
             }
         }
-        JsonOperation::Convert { input, to } => {
-            if *to != "yaml" {
-                return error_result("JSON can only be converted to yaml");
-            }
+        JsonOperation::Convert { input, to, root } => {
             let input = get_input_string(input);
-            match json::convert_to_yaml(&input) {
-                Ok(json) => text_result(json),
-                Err(e) => error_result(&e),
+            match to.as_str() {
+                "yaml" => match json::convert_to_yaml(&input) {
+                    Ok(json) => text_result(json),
+                    Err(e) => error_result(&e),
+                },
+                "xml" => match json::convert_to_xml(&input, root.as_deref()) {
+                    Ok(xml) => text_result(xml),
+                    Err(e) => error_result(&e),
+                },
+                _ => error_result("JSON can only be converted to yaml or xml"),
             }
         }
     }
@@ -72,6 +76,16 @@ pub fn handle_xml(operation: &XmlOperation) -> CommandResult {
             let input = get_input_string(input);
             match xml::minify(&input) {
                 Ok(xml) => text_result(xml),
+                Err(e) => error_result(&e),
+            }
+        }
+        XmlOperation::Convert { input, to } => {
+            if *to != "json" {
+                return error_result("XML can only be converted to json");
+            }
+            let input = get_input_string(input);
+            match xml::convert_to_json(&input) {
+                Ok(json) => text_result(json),
                 Err(e) => error_result(&e),
             }
         }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strapd-core"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 
 [dependencies]

--- a/crates/core/src/data_formats/json.rs
+++ b/crates/core/src/data_formats/json.rs
@@ -103,13 +103,12 @@ fn json_to_yaml(value: &JsonValue) -> Result<Yaml, String> {
             }
             Ok(Yaml::Hash(hash))
         }
-        JsonValue::Array(_) => {
-            let array: Vec<Yaml> = value
+        JsonValue::Array(_) => Ok(Yaml::Array(
+            value
                 .members()
                 .map(json_to_yaml)
-                .collect::<Result<Vec<Yaml>, String>>()?;
-            Ok(Yaml::Array(array))
-        }
+                .collect::<Result<_, _>>()?,
+        )),
         JsonValue::String(s) => Ok(Yaml::String(s.to_string())),
         JsonValue::Number(n) => match n.to_string().parse::<i64>() {
             Ok(i) => Ok(Yaml::Integer(i)),

--- a/crates/core/src/data_formats/json.rs
+++ b/crates/core/src/data_formats/json.rs
@@ -1,3 +1,4 @@
+use crate::data_formats::xml;
 use json::{self as json_builtin, JsonValue};
 use yaml_rust::{YamlEmitter, yaml::Hash, yaml::Yaml};
 
@@ -41,6 +42,33 @@ pub fn convert_to_yaml(input: &str) -> Result<String, String> {
     Ok(output)
 }
 
+pub fn convert_to_xml(input: &str, root_name: Option<&str>) -> Result<String, String> {
+    let parsed = json_builtin::parse(input).map_err(|e| format!("Invalid JSON input: {e}"))?;
+
+    if let Some(provided_root) = root_name {
+        json_to_xml(&parsed, provided_root)
+    } else {
+        match &parsed {
+            JsonValue::Object(_) => {
+                let mut entries_iter = parsed.entries();
+                if let Some((key, value)) = entries_iter.next() {
+                    if entries_iter.next().is_none() {
+                        // Single key object: use the key as root and pass the value
+                        json_to_xml(value, key)
+                    } else {
+                        // Multiple keys: use default root with full object
+                        json_to_xml(&parsed, "root")
+                    }
+                } else {
+                    // Empty object: use default root
+                    json_to_xml(&parsed, "root")
+                }
+            }
+            _ => json_to_xml(&parsed, "root"),
+        }
+    }
+}
+
 fn sort_json_keys(value: &JsonValue) -> JsonValue {
     match value {
         JsonValue::Object(_) => {
@@ -76,19 +104,110 @@ fn json_to_yaml(value: &JsonValue) -> Result<Yaml, String> {
             Ok(Yaml::Hash(hash))
         }
         JsonValue::Array(_) => {
-            let array: Result<Vec<Yaml>, String> = value.members().map(json_to_yaml).collect();
-            Ok(Yaml::Array(array?))
+            let array: Vec<Yaml> = value
+                .members()
+                .map(json_to_yaml)
+                .collect::<Result<Vec<Yaml>, String>>()?;
+            Ok(Yaml::Array(array))
         }
         JsonValue::String(s) => Ok(Yaml::String(s.to_string())),
-        JsonValue::Number(n) => {
-            // Try to parse as integer first, then fall back to real
-            match n.to_string().parse::<i64>() {
-                Ok(i) => Ok(Yaml::Integer(i)),
-                Err(_) => Ok(Yaml::Real(n.to_string())),
-            }
-        }
+        JsonValue::Number(n) => match n.to_string().parse::<i64>() {
+            Ok(i) => Ok(Yaml::Integer(i)),
+            Err(_) => Ok(Yaml::Real(n.to_string())),
+        },
         JsonValue::Boolean(b) => Ok(Yaml::Boolean(*b)),
         JsonValue::Null => Ok(Yaml::Null),
         JsonValue::Short(s) => Ok(Yaml::String(s.to_string())),
+    }
+}
+
+fn json_to_xml(value: &JsonValue, key: &str) -> Result<String, String> {
+    let escaped_key = xml::escape(key);
+
+    match value {
+        JsonValue::Object(_) => {
+            let mut xml = String::with_capacity(256);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            for (k, v) in value.entries() {
+                xml.push_str(&json_to_xml(v, k)?);
+            }
+            xml.push_str("</");
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            Ok(xml)
+        }
+        JsonValue::Array(_) => {
+            let items: Vec<String> = value
+                .members()
+                .map(|item| json_to_xml(item, key))
+                .collect::<Result<Vec<String>, String>>()?;
+
+            if items.is_empty() {
+                let mut xml = String::with_capacity(escaped_key.len() + 5);
+                xml.push('<');
+                xml.push_str(&escaped_key);
+                xml.push_str(" />");
+                Ok(xml)
+            } else {
+                Ok(items.join(""))
+            }
+        }
+        JsonValue::String(s) => {
+            let escaped_s = xml::escape(s);
+            let mut xml = String::with_capacity(escaped_key.len() * 2 + escaped_s.len() + 5);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            xml.push_str(&escaped_s);
+            xml.push_str("</");
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            Ok(xml)
+        }
+        JsonValue::Number(n) => {
+            let n_str = n.to_string();
+            let mut xml = String::with_capacity(escaped_key.len() * 2 + n_str.len() + 5);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            xml.push_str(&n_str);
+            xml.push_str("</");
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            Ok(xml)
+        }
+        JsonValue::Boolean(b) => {
+            let b_str = b.to_string();
+            let mut xml = String::with_capacity(escaped_key.len() * 2 + b_str.len() + 5);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            xml.push_str(&b_str);
+            xml.push_str("</");
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            Ok(xml)
+        }
+        JsonValue::Null => {
+            let mut xml = String::with_capacity(escaped_key.len() + 5);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push_str(" />");
+            Ok(xml)
+        }
+        JsonValue::Short(s) => {
+            let escaped_s = xml::escape(s);
+            let mut xml = String::with_capacity(escaped_key.len() * 2 + escaped_s.len() + 5);
+            xml.push('<');
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            xml.push_str(&escaped_s);
+            xml.push_str("</");
+            xml.push_str(&escaped_key);
+            xml.push('>');
+            Ok(xml)
+        }
     }
 }

--- a/crates/core/src/data_formats/mod.rs
+++ b/crates/core/src/data_formats/mod.rs
@@ -1,4 +1,5 @@
 pub mod json;
 pub mod sql;
+mod util;
 pub mod xml;
 pub mod yaml;

--- a/crates/core/src/data_formats/util.rs
+++ b/crates/core/src/data_formats/util.rs
@@ -1,0 +1,28 @@
+/// Normalizes XML whitespace to canonical JSON format.
+/// WHY necessary: XML preserves all whitespace (newlines, indentation) literally. A formatted XML
+/// element like `<description>\n  Hello\n  World\n</description>` should become `"Hello World"` in JSON,
+/// not `"\n  Hello\n  World\n"`. Trim removes formatting artifacts; split/join collapses internal
+/// whitespace while preserving semantic content like spaces in "a & b".
+pub(crate) fn normalize_whitespace(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        String::new()
+    } else {
+        let mut result = String::with_capacity(trimmed.len());
+        let mut in_whitespace = false;
+
+        for c in trimmed.chars() {
+            if c.is_whitespace() {
+                if !in_whitespace && !result.is_empty() {
+                    result.push(' ');
+                    in_whitespace = true;
+                }
+            } else {
+                result.push(c);
+                in_whitespace = false;
+            }
+        }
+
+        result
+    }
+}

--- a/crates/core/src/data_formats/xml.rs
+++ b/crates/core/src/data_formats/xml.rs
@@ -71,11 +71,12 @@ pub(crate) fn escape(s: &str) -> String {
     result
 }
 
-/// Unescapes XML entity references using placeholder-based two-pass replacement.
-/// WHY placeholder technique: Direct sequential replacement of "&amp;" to "&" would corrupt other
-/// entities. For example, "&amp;lt;" should decode to "&lt;" (the literal text), but if we replace
-/// "&amp;" first, we'd get "&lt;" → "<" (wrong!). Placeholder defers "&amp;" replacement until
-/// after other entities are replaced, preventing this corruption.
+/// Unescapes XML entity references using a single-pass, entity-by-entity parser.
+/// WHY: We scan the input once, detecting sequences like `&name;` and replacing only recognized
+/// entities (e.g., `&amp;`, `&lt;`, `&gt;`, `&quot;`, `&apos;`) with their character equivalents.
+/// Unrecognized or incomplete entities are left intact. This also correctly handles inputs such
+/// as `&amp;lt;`, which becomes `&lt;`: we decode only the leading `&amp;` and then treat the
+/// remaining `lt;` as literal text rather than a second entity.
 pub(crate) fn unescape(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();

--- a/crates/core/src/data_formats/xml.rs
+++ b/crates/core/src/data_formats/xml.rs
@@ -1,5 +1,8 @@
+use crate::data_formats::util::normalize_whitespace;
+use json::JsonValue;
 use quick_xml::events::Event;
 use quick_xml::{Reader, Writer};
+use std::collections::HashMap;
 
 pub fn beautify(input: &str, spaces: u8) -> Result<String, String> {
     format(input, Some(spaces))
@@ -7,6 +10,13 @@ pub fn beautify(input: &str, spaces: u8) -> Result<String, String> {
 
 pub fn minify(input: &str) -> Result<String, String> {
     format(input, None)
+}
+
+pub fn convert_to_json(input: &str) -> Result<String, String> {
+    let mut reader = Reader::from_str(input);
+    reader.config_mut().trim_text(false);
+    let json_value = xml_to_json_element(&mut reader)?;
+    Ok(json::stringify(json_value))
 }
 
 fn format(input: &str, spaces: Option<u8>) -> Result<String, String> {
@@ -28,4 +38,186 @@ fn format(input: &str, spaces: Option<u8>) -> Result<String, String> {
         }
     }
     String::from_utf8(writer.into_inner()).map_err(|e| format!("UTF-8 conversion error: {e}"))
+}
+
+/// Maps XML entity names to their character equivalents
+fn entity_to_char(entity_name: &str) -> Option<&'static str> {
+    match entity_name {
+        "amp" => Some("&"),
+        "lt" => Some("<"),
+        "gt" => Some(">"),
+        "quot" => Some("\""),
+        "apos" => Some("'"),
+        _ => None,
+    }
+}
+
+/// Escapes special XML characters to prevent parser misinterpretation.
+/// WHY: Characters like &, <, >, ", ' have syntactic meaning in XML and must be escaped so they're
+/// treated as literal content rather than markup/delimiters. Without escaping, `<message>1 < 2</message>`
+/// would be invalid (parser thinks "<" starts a tag).
+pub(crate) fn escape(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => result.push_str("&amp;"),
+            '<' => result.push_str("&lt;"),
+            '>' => result.push_str("&gt;"),
+            '"' => result.push_str("&quot;"),
+            '\'' => result.push_str("&apos;"),
+            _ => result.push(c),
+        }
+    }
+    result
+}
+
+/// Unescapes XML entity references using placeholder-based two-pass replacement.
+/// WHY placeholder technique: Direct sequential replacement of "&amp;" to "&" would corrupt other
+/// entities. For example, "&amp;lt;" should decode to "&lt;" (the literal text), but if we replace
+/// "&amp;" first, we'd get "&lt;" → "<" (wrong!). Placeholder defers "&amp;" replacement until
+/// after other entities are replaced, preventing this corruption.
+pub(crate) fn unescape(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if c == '&' {
+            let mut entity = String::new();
+
+            while let Some(&next) = chars.peek() {
+                if next == ';' {
+                    chars.next();
+                    break;
+                }
+                entity.push(chars.next().unwrap());
+            }
+
+            if let Some(entity_char) = entity_to_char(&entity) {
+                result.push_str(entity_char);
+            } else {
+                // Not a recognized entity, keep it as-is
+                result.push('&');
+                result.push_str(&entity);
+                result.push(';');
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+fn xml_to_json_element(reader: &mut Reader<&[u8]>) -> Result<JsonValue, String> {
+    let mut root = None;
+    let mut buf = Vec::with_capacity(8192);
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let tag_name = String::from_utf8(e.name().as_ref().to_vec())
+                    .map_err(|_| "Failed to decode tag name".to_string())?;
+                let element_value = read_element(reader, &tag_name)?;
+
+                if root.is_none() {
+                    root = Some((tag_name, element_value));
+                } else {
+                    return Err("XML must have a single root element".to_string());
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(e) => return Err(format!("XML parse error: {e}")),
+        }
+        buf.clear();
+    }
+
+    match root {
+        Some((tag_name, value)) => {
+            let mut obj = JsonValue::new_object();
+            obj.insert(&tag_name, value)
+                .map_err(|_| "Failed to create JSON object".to_string())?;
+            Ok(obj)
+        }
+        None => Err("No XML elements found".to_string()),
+    }
+}
+
+fn read_element(reader: &mut Reader<&[u8]>, tag_name: &str) -> Result<JsonValue, String> {
+    let mut buf = Vec::with_capacity(8192);
+    let mut children: HashMap<String, Vec<JsonValue>> = HashMap::new();
+    let mut text_content = String::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) => {
+                let child_tag = String::from_utf8(e.name().as_ref().to_vec())
+                    .map_err(|_| "Failed to decode tag name".to_string())?;
+                let child_value = read_element(reader, &child_tag)?;
+                children.entry(child_tag).or_default().push(child_value);
+            }
+            Ok(Event::Text(ref e)) => {
+                // Convert bytes to string and unescape XML entities
+                let text = String::from_utf8(e.as_ref().to_vec())
+                    .map_err(|_| "Failed to decode text".to_string())?;
+                let unescaped = unescape(&text);
+                text_content.push_str(&unescaped);
+            }
+            Ok(Event::GeneralRef(ref e)) => {
+                // Handle XML entity references (e.g., &amp; &lt; &gt; &quot; &apos;)
+                let entity_name = String::from_utf8(e.as_ref().to_vec())
+                    .map_err(|_| "Failed to decode entity name".to_string())?;
+                if let Some(entity_char) = entity_to_char(&entity_name) {
+                    text_content.push_str(entity_char);
+                } else {
+                    return Err(format!("Unsupported entity reference: &{};", entity_name));
+                }
+            }
+            Ok(Event::End(ref e)) => {
+                let end_tag = String::from_utf8(e.name().as_ref().to_vec())
+                    .map_err(|_| "Failed to decode end tag".to_string())?;
+                if end_tag == tag_name {
+                    break;
+                }
+            }
+            Ok(Event::Eof) => return Err("Unexpected EOF while parsing element".to_string()),
+            Ok(_) => {}
+            Err(e) => return Err(format!("XML parse error: {e}")),
+        }
+        buf.clear();
+    }
+
+    let normalized_text = normalize_whitespace(&text_content);
+
+    if children.is_empty() && normalized_text.is_empty() {
+        Ok(JsonValue::Null)
+    } else if children.is_empty() {
+        Ok(JsonValue::String(normalized_text))
+    } else if normalized_text.is_empty() {
+        let mut obj = JsonValue::new_object();
+        for (key, values) in children {
+            let value = if values.len() == 1 {
+                values.into_iter().next().unwrap()
+            } else {
+                JsonValue::Array(values)
+            };
+            obj.insert(&key, value)
+                .map_err(|_| "Failed to create JSON object".to_string())?;
+        }
+        Ok(obj)
+    } else {
+        let mut obj = JsonValue::new_object();
+        obj.insert("#text", JsonValue::String(normalized_text))
+            .map_err(|_| "Failed to create JSON object".to_string())?;
+        for (key, values) in children {
+            let value = if values.len() == 1 {
+                values.into_iter().next().unwrap()
+            } else {
+                JsonValue::Array(values)
+            };
+            obj.insert(&key, value)
+                .map_err(|_| "Failed to create JSON object".to_string())?;
+        }
+        Ok(obj)
+    }
 }

--- a/crates/core/tests/data_formats/mod.rs
+++ b/crates/core/tests/data_formats/mod.rs
@@ -1,2 +1,3 @@
 pub mod json;
+pub mod xml;
 pub mod yaml;

--- a/crates/core/tests/data_formats/xml.rs
+++ b/crates/core/tests/data_formats/xml.rs
@@ -1,0 +1,314 @@
+use strapd_core::data_formats::xml::{beautify, convert_to_json, minify};
+
+// Tests for beautify
+#[test]
+fn test_beautify_simple_xml() {
+    let input = r#"<root><name>John</name><age>30</age></root>"#;
+    let result = beautify(input, 2).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("name"));
+    assert!(result.contains("John"));
+    // Should have newlines for formatting
+    assert!(result.contains("\n"));
+}
+
+#[test]
+fn test_beautify_nested_xml() {
+    let input = r#"<root><user><name>Alice</name></user></root>"#;
+    let result = beautify(input, 2).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("user"));
+    assert!(result.contains("name"));
+    assert!(result.contains("Alice"));
+}
+
+#[test]
+fn test_beautify_with_different_indentation() {
+    let input = r#"<root><name>Bob</name></root>"#;
+    let result = beautify(input, 4).unwrap();
+    assert!(result.contains("name"));
+    assert!(result.contains("Bob"));
+}
+
+#[test]
+fn test_beautify_with_attributes() {
+    let input = r#"<root id="1"><name>John</name></root>"#;
+    let result = beautify(input, 2).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("name"));
+}
+
+// Tests for minify
+#[test]
+fn test_minify_formatted_xml() {
+    let input = r#"<root>
+  <name>John</name>
+  <age>30</age>
+</root>"#;
+    let result = minify(input).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("name"));
+    assert!(result.contains("John"));
+    assert!(result.contains("age"));
+    assert!(result.contains("30"));
+}
+
+#[test]
+fn test_minify_already_compact_xml() {
+    let input = r#"<root><name>Alice</name></root>"#;
+    let result = minify(input).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("name"));
+    assert!(result.contains("Alice"));
+}
+
+#[test]
+fn test_minify_nested_xml() {
+    let input = r#"<root>
+  <user>
+    <name>Bob</name>
+    <email>bob@example.com</email>
+  </user>
+</root>"#;
+    let result = minify(input).unwrap();
+    assert!(result.contains("user"));
+    assert!(result.contains("name"));
+    assert!(result.contains("Bob"));
+    assert!(result.contains("email"));
+}
+
+#[test]
+fn test_minify_xml_with_attributes() {
+    let input = r#"<root id="123">
+  <name lang="en">Alice</name>
+</root>"#;
+    let result = minify(input).unwrap();
+    assert!(result.contains("root"));
+    assert!(result.contains("name"));
+    assert!(result.contains("Alice"));
+}
+
+// Tests for convert_to_json
+#[test]
+fn test_convert_simple_xml_to_json() {
+    let input = r#"<root><name>John</name><age>30</age></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify structure: root is top level object
+    assert!(parsed.is_object());
+    assert!(parsed.has_key("root"));
+
+    // Verify hierarchy: name and age are children of root
+    assert!(parsed["root"].is_object());
+    assert_eq!(parsed["root"]["name"], "John");
+    assert_eq!(parsed["root"]["age"], "30");
+
+    // Verify no extra keys
+    let mut keys = vec![];
+    for (k, _) in parsed["root"].entries() {
+        keys.push(k);
+    }
+    assert_eq!(keys.len(), 2);
+}
+
+#[test]
+fn test_convert_nested_xml_to_json() {
+    let input = r#"<root><user><name>Alice</name><email>alice@example.com</email></user></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify deep hierarchy
+    assert!(parsed["root"].is_object());
+    assert!(parsed["root"]["user"].is_object());
+
+    // Verify all values are correct
+    assert_eq!(parsed["root"]["user"]["name"], "Alice");
+    assert_eq!(parsed["root"]["user"]["email"], "alice@example.com");
+
+    // Verify user has exactly 2 keys
+    let mut user_keys = vec![];
+    for (k, _) in parsed["root"]["user"].entries() {
+        user_keys.push(k);
+    }
+    assert_eq!(user_keys.len(), 2);
+}
+
+#[test]
+fn test_convert_xml_with_array_to_json() {
+    let input = r#"<root><item>first</item><item>second</item><item>third</item></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify array is created for duplicate keys
+    assert!(parsed["root"]["item"].is_array());
+    assert_eq!(parsed["root"]["item"].len(), 3);
+
+    // Verify values in correct order
+    assert_eq!(parsed["root"]["item"][0], "first");
+    assert_eq!(parsed["root"]["item"][1], "second");
+    assert_eq!(parsed["root"]["item"][2], "third");
+}
+
+#[test]
+fn test_convert_empty_xml_element_to_json() {
+    let input = r#"<root><item>value</item></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify root structure
+    assert!(parsed.is_object());
+    assert!(parsed.has_key("root"));
+    assert!(parsed["root"].is_object());
+
+    // Verify content
+    assert!(parsed["root"].has_key("item"));
+    assert_eq!(parsed["root"]["item"], "value");
+
+    // Verify root has exactly 1 key
+    assert_eq!(parsed["root"].entries().count(), 1);
+}
+
+#[test]
+fn test_convert_xml_with_numbers_to_json() {
+    let input = r#"<root><count>42</count><price>19.99</price></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Numbers are kept as strings in XML conversion
+    assert_eq!(parsed["root"]["count"], "42");
+    assert_eq!(parsed["root"]["price"], "19.99");
+
+    // Verify they are strings, not numbers
+    assert!(parsed["root"]["count"].is_string());
+    assert!(parsed["root"]["price"].is_string());
+}
+
+#[test]
+fn test_convert_xml_with_booleans_to_json() {
+    let input = r#"<root><active>true</active><deleted>false</deleted></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Boolean text values are kept as strings
+    assert_eq!(parsed["root"]["active"], "true");
+    assert_eq!(parsed["root"]["deleted"], "false");
+    assert!(parsed["root"]["active"].is_string());
+    assert!(parsed["root"]["deleted"].is_string());
+}
+
+#[test]
+fn test_convert_deeply_nested_xml_to_json() {
+    let input =
+        r#"<root><level1><level2><level3><value>deep</value></level3></level2></level1></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify complete hierarchy chain
+    assert!(parsed["root"].is_object());
+    assert!(parsed["root"]["level1"].is_object());
+    assert!(parsed["root"]["level1"]["level2"].is_object());
+    assert!(parsed["root"]["level1"]["level2"]["level3"].is_object());
+
+    // Verify final value
+    assert_eq!(
+        parsed["root"]["level1"]["level2"]["level3"]["value"],
+        "deep"
+    );
+
+    // Verify each level has exactly 1 key
+    assert_eq!(parsed["root"].entries().count(), 1);
+    assert_eq!(parsed["root"]["level1"].entries().count(), 1);
+    assert_eq!(parsed["root"]["level1"]["level2"].entries().count(), 1);
+    assert_eq!(
+        parsed["root"]["level1"]["level2"]["level3"]
+            .entries()
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn test_convert_xml_with_special_chars_to_json() {
+    // Test with literal characters (not entities in XML)
+    let input = r#"<root><text>Hello and goodbye</text></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify structure is correct
+    assert!(parsed["root"].is_object());
+    assert!(parsed["root"].has_key("text"));
+
+    // Verify text value is correct
+    let text_value = parsed["root"]["text"].as_str().unwrap();
+    assert_eq!(text_value, "Hello and goodbye");
+}
+
+#[test]
+fn test_convert_invalid_xml_to_json() {
+    let input = r#"<root><unclosed>"#;
+    let result = convert_to_json(input);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_convert_xml_multiple_roots_to_json() {
+    let input = r#"<root><data>1</data></root><root><data>2</data></root>"#;
+    let result = convert_to_json(input);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_convert_xml_unicode_to_json() {
+    let input = r#"<root><greeting>Hello 世界</greeting></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+    assert!(
+        parsed["root"]["greeting"]
+            .as_str()
+            .unwrap()
+            .contains("世界")
+    );
+}
+
+#[test]
+fn test_beautify_then_minify_roundtrip() {
+    let input = r#"<root><name>John</name></root>"#;
+    let beautified = beautify(input, 2).unwrap();
+    let minified = minify(&beautified).unwrap();
+    let original_minified = minify(input).unwrap();
+    // Both should parse to the same structure
+    let parsed1 = json::parse(&convert_to_json(&minified).unwrap()).unwrap();
+    let parsed2 = json::parse(&convert_to_json(&original_minified).unwrap()).unwrap();
+    assert_eq!(parsed1, parsed2);
+}
+
+#[test]
+fn test_convert_xml_with_entities_to_json() {
+    let input = r#"<root><text>Ampersand &amp; LessThan &lt; GreaterThan &gt; Quote &quot; Apostrophe &apos;</text></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify structure
+    assert!(parsed["root"].is_object());
+    assert!(parsed["root"].has_key("text"));
+
+    // Verify all entities are properly decoded and spaces preserved
+    let text_value = parsed["root"]["text"].as_str().unwrap();
+    assert_eq!(
+        text_value,
+        "Ampersand & LessThan < GreaterThan > Quote \" Apostrophe '"
+    );
+}
+
+#[test]
+fn test_convert_xml_with_mixed_entities_and_text_to_json() {
+    let input = r#"<root><data>Hello &amp; world &lt;test&gt; &quot;quoted&quot;</data></root>"#;
+    let result = convert_to_json(input).unwrap();
+    let parsed = json::parse(&result).unwrap();
+
+    // Verify structure and content
+    assert!(parsed["root"].is_object());
+    let data_value = parsed["root"]["data"].as_str().unwrap();
+    assert_eq!(data_value, "Hello & world <test> \"quoted\"");
+}

--- a/crates/wasm/Cargo.toml
+++ b/crates/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strapd-wasm"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2024"
 
 [lib]

--- a/crates/wasm/src/data_formats_ops.rs
+++ b/crates/wasm/src/data_formats_ops.rs
@@ -48,3 +48,19 @@ pub fn yaml_to_json(input: &str) -> String {
         Err(e) => format!("Error: {}", e),
     }
 }
+
+#[wasm_bindgen]
+pub fn json_to_xml(input: &str, root: Option<String>) -> String {
+    match data_formats::json::convert_to_xml(input, root.as_deref()) {
+        Ok(result) => result,
+        Err(e) => format!("Error: {}", e),
+    }
+}
+
+#[wasm_bindgen]
+pub fn xml_to_json(input: &str) -> String {
+    match data_formats::xml::convert_to_json(input) {
+        Ok(result) => result,
+        Err(e) => format!("Error: {}", e),
+    }
+}

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapd-webapp",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/webapp/src/components/common/tool-interface.tsx
+++ b/webapp/src/components/common/tool-interface.tsx
@@ -35,9 +35,9 @@ export const ToolInterface: React.FC<ToolInterfaceProps> = ({
   const ToolComponent = toolDefinition.component;
 
   return (
-    <Box w="full">
+    <VStack w="full" h="tool.container" align="stretch" spacing={6}>
       {/* Tool Header */}
-      <VStack align="stretch" spacing={4} mb={6}>
+      <VStack align="stretch" spacing={4}>
         <HStack spacing={3}>
           <Text fontSize="2xl">{getCategoryIcon(tool.category)}</Text>
           <Heading size="lg" color="text.primary">
@@ -50,11 +50,13 @@ export const ToolInterface: React.FC<ToolInterfaceProps> = ({
         <Divider />
       </VStack>
 
-      <ToolComponent
-        tool={toolDefinition}
-        initialInputs={initialInput || {}}
-        onInputChange={onInputChange}
-      />
-    </Box>
+      <Box flex={1} minH="0">
+        <ToolComponent
+          tool={toolDefinition}
+          initialInputs={initialInput || {}}
+          onInputChange={onInputChange}
+        />
+      </Box>
+    </VStack>
   );
 };

--- a/webapp/src/components/tools/base-tool.tsx
+++ b/webapp/src/components/tools/base-tool.tsx
@@ -195,8 +195,10 @@ export const BaseToolLayout: React.FC<{
   error?: string;
 }> = ({ children, onProcess, onClear, isProcessing, error }) => {
   return (
-    <VStack spacing={6} align="stretch">
-      {children}
+    <VStack spacing={6} align="stretch" h="full">
+      <VStack spacing={6} align="stretch" flex={1} minH="0">
+        {children}
+      </VStack>
 
       {error && (
         <Alert status="error" rounded="md">

--- a/webapp/src/components/tools/data-formats/converter-tool.tsx
+++ b/webapp/src/components/tools/data-formats/converter-tool.tsx
@@ -4,6 +4,7 @@ import {
   HStack,
   Select,
   Spacer,
+  Switch,
   Text,
   Textarea,
   VStack,
@@ -73,8 +74,8 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
       isProcessing={isProcessing}
       error={error}
     >
-      <VStack spacing={6} align="stretch">
-        <HStack spacing={5} align="end">
+      <VStack spacing={6} align="stretch" h="full">
+        <HStack spacing={5} align="flex-end">
           <FormControl width="200px">
             <FormLabel fontSize="sm" mb={1}>
               Source Format
@@ -88,6 +89,7 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
               <option value="auto">Auto-detect</option>
               <option value="json">JSON</option>
               <option value="yaml">YAML</option>
+              <option value="xml">XML</option>
             </Select>
           </FormControl>
 
@@ -107,12 +109,24 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
             >
               <option value="json">JSON</option>
               <option value="yaml">YAML</option>
+              <option value="xml">XML</option>
             </Select>
+          </FormControl>
+
+          <FormControl width="auto">
+            <FormLabel fontSize="sm" mb={1}>
+              Minify
+            </FormLabel>
+            <Switch
+              id="minify"
+              isChecked={Boolean(inputs.minify)}
+              onChange={(e) => updateInput("minify", e.target.checked)}
+            />
           </FormControl>
         </HStack>
 
-        <HStack spacing={6} align="start">
-          <VStack flex={1} align="stretch" spacing={3}>
+        <HStack spacing={6} align="stretch" flex={1} minH="0">
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 Input ({getSourceFormatDisplay()})
@@ -123,7 +137,8 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
               data-testid="tool-default-input"
               ref={inputRef}
               variant="input"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(inputs.text || "")}
               onChange={(e) => {
                 updateInput("text", e.target.value);
@@ -131,7 +146,7 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
               placeholder="Enter data to convert..."
             />
           </VStack>
-          <VStack flex={1} align="stretch" spacing={3}>
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 Output ({targetFormat.toUpperCase()})
@@ -141,7 +156,8 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
             </HStack>
             <Textarea
               variant="output"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(outputs.result || "")}
               placeholder="Converted output..."
             />

--- a/webapp/src/components/tools/data-formats/converter-tool.tsx
+++ b/webapp/src/components/tools/data-formats/converter-tool.tsx
@@ -75,7 +75,7 @@ export const ConverterToolComponent: React.FC<BaseToolProps> = ({
       error={error}
     >
       <VStack spacing={6} align="stretch" h="full">
-        <HStack spacing={5} align="flex-end">
+        <HStack spacing={5} align="end">
           <FormControl width="200px">
             <FormLabel fontSize="sm" mb={1}>
               Source Format

--- a/webapp/src/components/tools/data-formats/json-tool.tsx
+++ b/webapp/src/components/tools/data-formats/json-tool.tsx
@@ -54,7 +54,7 @@ export const JsonToolComponent: React.FC<BaseToolProps> = ({
       isProcessing={isProcessing}
       error={error}
     >
-      <VStack spacing={6} align="stretch">
+      <VStack spacing={6} align="stretch" h="full">
         <HStack spacing={8} align="end">
           <FormControl display="flex" alignItems="center" w="auto">
             <FormLabel htmlFor="sort-keys" mb="0">
@@ -98,8 +98,8 @@ export const JsonToolComponent: React.FC<BaseToolProps> = ({
           </FormControl>
         </HStack>
 
-        <HStack spacing={6} align="start">
-          <VStack flex={1} align="stretch" spacing={3}>
+        <HStack spacing={6} align="stretch" flex={1} minH="0">
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 JSON Input
@@ -110,7 +110,8 @@ export const JsonToolComponent: React.FC<BaseToolProps> = ({
               data-testid="tool-default-input"
               ref={inputRef}
               variant="input"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(inputs.text || "")}
               onChange={(e) => {
                 updateInput("text", e.target.value);
@@ -118,7 +119,7 @@ export const JsonToolComponent: React.FC<BaseToolProps> = ({
               placeholder="Enter JSON to format..."
             />
           </VStack>
-          <VStack flex={1} align="stretch" spacing={3}>
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 Result
@@ -128,7 +129,8 @@ export const JsonToolComponent: React.FC<BaseToolProps> = ({
             </HStack>
             <Textarea
               variant="output"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(outputs.result || "")}
               placeholder="Result..."
             />

--- a/webapp/src/components/tools/data-formats/xml-tool.tsx
+++ b/webapp/src/components/tools/data-formats/xml-tool.tsx
@@ -53,7 +53,7 @@ export const XmlToolComponent: React.FC<BaseToolProps> = ({
       isProcessing={isProcessing}
       error={error}
     >
-      <VStack spacing={6} align="stretch">
+      <VStack spacing={6} align="stretch" h="full">
         <HStack spacing={8} align="end">
           <FormControl display="flex" alignItems="center" w="auto">
             <FormLabel htmlFor="minify" mb="0">
@@ -87,8 +87,8 @@ export const XmlToolComponent: React.FC<BaseToolProps> = ({
           </FormControl>
         </HStack>
 
-        <HStack spacing={6} align="start">
-          <VStack flex={1} align="stretch" spacing={3}>
+        <HStack spacing={6} align="stretch" flex={1} minH="0">
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 XML Input
@@ -99,7 +99,8 @@ export const XmlToolComponent: React.FC<BaseToolProps> = ({
               data-testid="tool-default-input"
               ref={inputRef}
               variant="input"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(inputs.text || "")}
               onChange={(e) => {
                 updateInput("text", e.target.value);
@@ -107,7 +108,7 @@ export const XmlToolComponent: React.FC<BaseToolProps> = ({
               placeholder="Enter XML to format..."
             />
           </VStack>
-          <VStack flex={1} align="stretch" spacing={3}>
+          <VStack flex={1} align="stretch" spacing={3} h="full">
             <HStack minH="8">
               <Text fontSize="sm" fontWeight="medium" color="text.secondary">
                 Result
@@ -117,7 +118,8 @@ export const XmlToolComponent: React.FC<BaseToolProps> = ({
             </HStack>
             <Textarea
               variant="output"
-              minH="400px"
+              h="full"
+              minH="tool.textarea.min"
               value={String(outputs.result || "")}
               placeholder="Result..."
             />

--- a/webapp/src/components/tools/single-input-output-tool.tsx
+++ b/webapp/src/components/tools/single-input-output-tool.tsx
@@ -43,9 +43,9 @@ export const SingleInputOutputTool: React.FC<SingleInputOutputToolProps> = ({
       isProcessing={isProcessing}
       error={error}
     >
-      <HStack spacing={6} align="start">
+      <HStack spacing={6} align="stretch" flex={1} minH="0">
         {/* Input Section */}
-        <VStack flex={1} align="stretch" spacing={3}>
+        <VStack flex={1} align="stretch" spacing={3} h="full">
           <HStack minH="8">
             <Text fontSize="sm" fontWeight="medium" color="text.secondary">
               {inputLabel}
@@ -68,7 +68,7 @@ export const SingleInputOutputTool: React.FC<SingleInputOutputToolProps> = ({
         </VStack>
 
         {/* Output Section */}
-        <VStack flex={1} align="stretch" spacing={3}>
+        <VStack flex={1} align="stretch" spacing={3} h="full">
           <HStack minH="8">
             <Text fontSize="sm" fontWeight="medium" color="text.secondary">
               {outputLabel}

--- a/webapp/src/config/theme.ts
+++ b/webapp/src/config/theme.ts
@@ -256,6 +256,11 @@ const theme = extendTheme({
         _dark: "#2a2a2a", // Slightly lighter than main background for better separation
       },
     },
+    sizes: {
+      // Tool interface heights - calculated to fill viewport minus header and padding
+      "tool.container": "calc(100vh - 180px)",
+      "tool.textarea.min": "300px",
+    },
   },
 
   // Component styles

--- a/webapp/src/lib/utils/data-formats/index.test.ts
+++ b/webapp/src/lib/utils/data-formats/index.test.ts
@@ -1,0 +1,338 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { wasmWrapper } from "../../wasm";
+import { dataFormatsOperations, detectFormat } from "./index";
+
+const mockedWasm = vi.mocked(wasmWrapper);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("detectFormat", () => {
+  describe("JSON Detection", () => {
+    it("detects JSON from object", () => {
+      expect(detectFormat('{"key": "value"}')).toBe("json");
+    });
+
+    it("detects JSON from array", () => {
+      expect(detectFormat("[1, 2, 3]")).toBe("json");
+    });
+
+    it("detects JSON with whitespace", () => {
+      expect(detectFormat('  \n{"key": "value"}')).toBe("json");
+    });
+
+    it("detects empty JSON array", () => {
+      expect(detectFormat("[]")).toBe("json");
+    });
+
+    it("detects empty JSON object", () => {
+      expect(detectFormat("{}")).toBe("json");
+    });
+  });
+
+  describe("XML Detection", () => {
+    it("detects XML from element", () => {
+      expect(detectFormat("<root>content</root>")).toBe("xml");
+    });
+
+    it("detects XML from self-closing tag", () => {
+      expect(detectFormat("<root />")).toBe("xml");
+    });
+
+    it("detects XML declaration", () => {
+      expect(detectFormat("<?xml version='1.0'?>")).toBe("xml");
+    });
+
+    it("detects XML with attributes", () => {
+      expect(detectFormat('<root attr="value">content</root>')).toBe("xml");
+    });
+
+    it("detects XML with whitespace", () => {
+      expect(detectFormat("  \n<root>content</root>")).toBe("xml");
+    });
+  });
+
+  describe("YAML Detection", () => {
+    it("detects YAML from key-value", () => {
+      expect(detectFormat("key: value")).toBe("yaml");
+    });
+
+    it("detects YAML with hyphenated key", () => {
+      expect(detectFormat("api-key: secret")).toBe("yaml");
+    });
+
+    it("detects YAML with underscore key", () => {
+      expect(detectFormat("api_key: secret")).toBe("yaml");
+    });
+
+    it("detects YAML with whitespace", () => {
+      expect(detectFormat("  \nkey: value")).toBe("yaml");
+    });
+
+    it("does not confuse JSON-like YAML", () => {
+      expect(detectFormat("{key: value}")).toBe("json");
+    });
+  });
+
+  describe("Unknown Format", () => {
+    it("returns unknown for empty string", () => {
+      expect(detectFormat("")).toBe("unknown");
+    });
+
+    it("returns unknown for whitespace only", () => {
+      expect(detectFormat("   \n\t  ")).toBe("unknown");
+    });
+
+    it("returns unknown for plain text", () => {
+      expect(detectFormat("this is plain text")).toBe("unknown");
+    });
+
+    it("returns unknown for numbers", () => {
+      expect(detectFormat("12345")).toBe("unknown");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("handles Unicode in JSON", () => {
+      expect(detectFormat('{"name": "José"}')).toBe("json");
+    });
+
+    it("handles Unicode in XML", () => {
+      expect(detectFormat("<name>José</name>")).toBe("xml");
+    });
+
+    it("handles tabs", () => {
+      expect(detectFormat('\t\t{"key": "value"}')).toBe("json");
+    });
+
+    it("detects consistently", () => {
+      const input = '{"test": [1, 2, 3]}';
+      expect(detectFormat(input)).toBe("json");
+      expect(detectFormat(input)).toBe("json");
+    });
+  });
+});
+
+describe("dataFormatsOperations.convert", () => {
+  describe("Same Format Conversions", () => {
+    describe("JSON to JSON", () => {
+      it("beautifies by default", () => {
+        const input = '{"a":1}';
+        const result = dataFormatsOperations.convert(input, "json", "json");
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_beautify).toHaveBeenCalledWith(input, false, 2);
+        expect(mockedWasm.json_minify).not.toHaveBeenCalled();
+      });
+
+      it("minifies when minify=true", () => {
+        const input = '{\n  "a": 1\n}';
+        const result = dataFormatsOperations.convert(input, "json", "json", {
+          minify: true,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_minify).toHaveBeenCalledWith(input, false);
+        expect(mockedWasm.json_beautify).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("XML to XML", () => {
+      it("beautifies by default", () => {
+        const input = "<root><item>value</item></root>";
+        const result = dataFormatsOperations.convert(input, "xml", "xml");
+        expect(result.success).toBe(true);
+        expect(mockedWasm.xml_beautify).toHaveBeenCalledWith(input, 2);
+        expect(mockedWasm.xml_minify).not.toHaveBeenCalled();
+      });
+
+      it("minifies when minify=true", () => {
+        const input = "<root>\n  <item>value</item>\n</root>";
+        const result = dataFormatsOperations.convert(input, "xml", "xml", {
+          minify: true,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.xml_minify).toHaveBeenCalledWith(input);
+        expect(mockedWasm.xml_beautify).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("Cross Format Conversions", () => {
+    describe("JSON to YAML", () => {
+      it("converts successfully", () => {
+        const input = '{"key":"value"}';
+        const result = dataFormatsOperations.convert(input, "json", "yaml");
+        expect(result.success).toBe(true);
+        expect(result.result).toBe("key: value");
+        expect(mockedWasm.json_to_yaml).toHaveBeenCalledWith(input);
+      });
+    });
+
+    describe("YAML to JSON", () => {
+      it("converts and beautifies by default", () => {
+        const input = "key: value";
+        const result = dataFormatsOperations.convert(input, "yaml", "json");
+        expect(result.success).toBe(true);
+        expect(result.result).toContain("key");
+        expect(mockedWasm.yaml_to_json).toHaveBeenCalledWith(input);
+        expect(mockedWasm.json_beautify).toHaveBeenCalled();
+      });
+
+      it("skips beautification when minify=true", () => {
+        const input = "key: value";
+        const result = dataFormatsOperations.convert(input, "yaml", "json", {
+          minify: true,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.yaml_to_json).toHaveBeenCalledWith(input);
+        expect(mockedWasm.json_beautify).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("JSON to XML", () => {
+      it("converts successfully", () => {
+        const input = '{"user":"Bob"}';
+        const result = dataFormatsOperations.convert(input, "json", "xml");
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_to_xml).toHaveBeenCalledWith(input, null);
+      });
+
+      it("passes rootName option", () => {
+        const input = '{"user":"Bob"}';
+        const result = dataFormatsOperations.convert(input, "json", "xml", {
+          rootName: "data",
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_to_xml).toHaveBeenCalledWith(input, "data");
+      });
+
+      it("beautifies by default", () => {
+        const input = '{"user":"Bob"}';
+        const result = dataFormatsOperations.convert(input, "json", "xml", {
+          minify: false,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_to_xml).toHaveBeenCalled();
+        expect(mockedWasm.xml_beautify).toHaveBeenCalled();
+      });
+
+      it("skips beautification when minify=true", () => {
+        const input = '{"user":"Bob"}';
+        const result = dataFormatsOperations.convert(input, "json", "xml", {
+          minify: true,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.json_to_xml).toHaveBeenCalled();
+        expect(mockedWasm.xml_beautify).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("XML to JSON", () => {
+      it("converts successfully", () => {
+        const input = "<root><item>value</item></root>";
+        const result = dataFormatsOperations.convert(input, "xml", "json");
+        expect(result.success).toBe(true);
+        expect(mockedWasm.xml_to_json).toHaveBeenCalledWith(input);
+      });
+
+      it("beautifies by default", () => {
+        const input = "<root><item>value</item></root>";
+        const result = dataFormatsOperations.convert(input, "xml", "json", {
+          minify: false,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.xml_to_json).toHaveBeenCalled();
+        expect(mockedWasm.json_beautify).toHaveBeenCalled();
+      });
+
+      it("skips beautification when minify=true", () => {
+        const input = "<root><item>value</item></root>";
+        const result = dataFormatsOperations.convert(input, "xml", "json", {
+          minify: true,
+        });
+        expect(result.success).toBe(true);
+        expect(mockedWasm.xml_to_json).toHaveBeenCalled();
+        expect(mockedWasm.json_beautify).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("Error Handling", () => {
+    it("returns error for unknown source format", () => {
+      const result = dataFormatsOperations.convert("input", "unknown", "json");
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it("returns error for unsupported conversion", () => {
+      const result = dataFormatsOperations.convert("input", "json", "unknown");
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+});
+
+describe("dataFormatsOperations individual functions", () => {
+  it("jsonBeautify calls WASM with correct parameters", () => {
+    const input = '{"a":1}';
+    const result = dataFormatsOperations.jsonBeautify(input, false, 2);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.json_beautify).toHaveBeenCalledWith(input, false, 2);
+  });
+
+  it("jsonMinify calls WASM with correct parameters", () => {
+    const input = '{\n  "a": 1\n}';
+    const result = dataFormatsOperations.jsonMinify(input, false);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.json_minify).toHaveBeenCalledWith(input, false);
+  });
+
+  it("xmlBeautify calls WASM with correct parameters", () => {
+    const input = "<root><item /></root>";
+    const result = dataFormatsOperations.xmlBeautify(input, 2);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.xml_beautify).toHaveBeenCalledWith(input, 2);
+  });
+
+  it("xmlMinify calls WASM with correct parameters", () => {
+    const input = "<root>\n  <item />\n</root>";
+    const result = dataFormatsOperations.xmlMinify(input);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.xml_minify).toHaveBeenCalledWith(input);
+  });
+
+  it("jsonToYaml calls WASM with correct parameters", () => {
+    const input = '{"key":"value"}';
+    const result = dataFormatsOperations.jsonToYaml(input);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.json_to_yaml).toHaveBeenCalledWith(input);
+  });
+
+  it("yamlToJson calls WASM with correct parameters", () => {
+    const input = "key: value";
+    const result = dataFormatsOperations.yamlToJson(input);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.yaml_to_json).toHaveBeenCalledWith(input);
+  });
+
+  it("jsonToXml without root calls WASM with null", () => {
+    const input = '{"data":"value"}';
+    const result = dataFormatsOperations.jsonToXml(input);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.json_to_xml).toHaveBeenCalledWith(input, null);
+  });
+
+  it("jsonToXml with root calls WASM with root name", () => {
+    const input = '{"data":"value"}';
+    const result = dataFormatsOperations.jsonToXml(input, "custom");
+    expect(result.success).toBe(true);
+    expect(mockedWasm.json_to_xml).toHaveBeenCalledWith(input, "custom");
+  });
+
+  it("xmlToJson calls WASM with correct parameters", () => {
+    const input = "<root><item>value</item></root>";
+    const result = dataFormatsOperations.xmlToJson(input);
+    expect(result.success).toBe(true);
+    expect(mockedWasm.xml_to_json).toHaveBeenCalledWith(input);
+  });
+});

--- a/webapp/src/lib/utils/data-formats/index.ts
+++ b/webapp/src/lib/utils/data-formats/index.ts
@@ -1,7 +1,7 @@
 import type { ToolResult } from "../../../types";
 import { wasmWrapper } from "../../wasm";
 
-export type DataFormat = "json" | "yaml" | "unknown";
+export type DataFormat = "json" | "yaml" | "xml" | "unknown";
 
 export function detectFormat(input: string): DataFormat {
   const trimmed = input.trim();
@@ -11,9 +11,8 @@ export function detectFormat(input: string): DataFormat {
   }
 
   // XML detection: starts with < or <?
-  // Note: XML is detected but returned as unknown since conversion not supported
   if (trimmed.startsWith("<")) {
-    return "unknown";
+    return "xml";
   }
 
   // JSON detection: starts with { or [
@@ -54,20 +53,36 @@ export const dataFormatsOperations = {
     return wasmWrapper.yaml_to_json(input);
   },
 
+  jsonToXml: (input: string, root?: string): ToolResult => {
+    return wasmWrapper.json_to_xml(input, root || null);
+  },
+
+  xmlToJson: (input: string): ToolResult => {
+    return wasmWrapper.xml_to_json(input);
+  },
+
   // Conversion router based on source and target formats
   convert: (
     input: string,
     sourceFormat: DataFormat,
     targetFormat: DataFormat,
+    options?: { rootName?: string; minify?: boolean },
   ): ToolResult => {
-    // Same format: beautify
+    const minify = options?.minify ?? false;
+
     if (sourceFormat === targetFormat) {
       switch (sourceFormat) {
         case "json":
-          return dataFormatsOperations.jsonBeautify(input, false, 2);
+          return minify
+            ? dataFormatsOperations.jsonMinify(input, false)
+            : dataFormatsOperations.jsonBeautify(input, false, 2);
         case "yaml":
-          // YAML doesn't have a beautify function, just return input
+          // YAML doesn't have a beautify/minify function, just return input
           return { success: true, result: input };
+        case "xml":
+          return minify
+            ? dataFormatsOperations.xmlMinify(input)
+            : dataFormatsOperations.xmlBeautify(input, 2);
         default:
           return { success: false, error: "Unknown format" };
       }
@@ -75,10 +90,33 @@ export const dataFormatsOperations = {
 
     // JSON ↔ YAML
     if (sourceFormat === "json" && targetFormat === "yaml") {
-      return dataFormatsOperations.jsonToYaml(input);
+      const result = dataFormatsOperations.jsonToYaml(input);
+      return result;
     }
     if (sourceFormat === "yaml" && targetFormat === "json") {
-      return dataFormatsOperations.yamlToJson(input);
+      const result = dataFormatsOperations.yamlToJson(input);
+      if (result.success && !minify && result.result) {
+        return dataFormatsOperations.jsonBeautify(result.result, false, 2);
+      }
+      return result;
+    }
+
+    // JSON → XML
+    if (sourceFormat === "json" && targetFormat === "xml") {
+      const result = dataFormatsOperations.jsonToXml(input, options?.rootName);
+      if (result.success && !minify && result.result) {
+        return dataFormatsOperations.xmlBeautify(result.result, 2);
+      }
+      return result;
+    }
+
+    // XML → JSON
+    if (sourceFormat === "xml" && targetFormat === "json") {
+      const result = dataFormatsOperations.xmlToJson(input);
+      if (result.success && !minify && result.result) {
+        return dataFormatsOperations.jsonBeautify(result.result, false, 2);
+      }
+      return result;
     }
 
     return { success: false, error: "Unsupported conversion" };

--- a/webapp/src/lib/wasm/index.ts
+++ b/webapp/src/lib/wasm/index.ts
@@ -52,6 +52,8 @@ export interface WasmModule {
   xml_minify: (input: string) => string;
   json_to_yaml: (input: string) => string;
   yaml_to_json: (input: string) => string;
+  json_to_xml: (input: string, root: string | null) => string;
+  xml_to_json: (input: string) => string;
 
   // Datetime
   datetime_now: (millis: boolean) => bigint;
@@ -342,6 +344,20 @@ export class WasmWrapper {
     return this.safeWasmCall(
       () => this.wasmModule.yaml_to_json(input),
       'yaml_to_json'
+    );
+  }
+
+  public json_to_xml(input: string, root: string | null): ToolResult {
+    return this.safeWasmCall(
+      () => this.wasmModule.json_to_xml(input, root),
+      'json_to_xml'
+    );
+  }
+
+  public xml_to_json(input: string): ToolResult {
+    return this.safeWasmCall(
+      () => this.wasmModule.xml_to_json(input),
+      'xml_to_json'
     );
   }
 

--- a/webapp/src/pages/cli.tsx
+++ b/webapp/src/pages/cli.tsx
@@ -338,7 +338,7 @@ strapd copy | strapd str upper | strapd paste`}
                   },
                   {
                     icon: "🔄",
-                    title: "YAML ⇄ JSON",
+                    title: "YAML ⇄ JSON, XML ⇄ JSON",
                     desc: "Bidirectional conversion",
                   },
                   { icon: "🔒", title: "Security", desc: "Hash, HMAC" },

--- a/webapp/src/test/setup.ts
+++ b/webapp/src/test/setup.ts
@@ -1,6 +1,44 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { afterEach } from "vitest";
+import { afterEach, vi } from "vitest";
+
+// Mock WASM module globally to avoid import issues in tests
+vi.mock("../lib/wasm", () => ({
+  wasmWrapper: {
+    json_beautify: vi.fn((input, _sort, spaces) => ({
+      success: true,
+      result: JSON.stringify(JSON.parse(input), null, spaces),
+    })),
+    json_minify: vi.fn((input) => ({
+      success: true,
+      result: JSON.stringify(JSON.parse(input)),
+    })),
+    xml_beautify: vi.fn((input) => ({
+      success: true,
+      result: input.replace(/></g, ">\n<"),
+    })),
+    xml_minify: vi.fn((input) => ({
+      success: true,
+      result: input.replace(/>\s+</g, "><"),
+    })),
+    json_to_yaml: vi.fn(() => ({
+      success: true,
+      result: "key: value",
+    })),
+    yaml_to_json: vi.fn(() => ({
+      success: true,
+      result: '{"key":"value"}',
+    })),
+    json_to_xml: vi.fn((input) => ({
+      success: true,
+      result: `<root>${input}</root>`,
+    })),
+    xml_to_json: vi.fn(() => ({
+      success: true,
+      result: '{"root":{"text":"content"}}',
+    })),
+  },
+}));
 
 // Cleanup after each test
 afterEach(() => {

--- a/webapp/src/tools/data-formats-tools.ts
+++ b/webapp/src/tools/data-formats-tools.ts
@@ -84,15 +84,17 @@ export const xmlTool: Tool = {
 const converterToolDefinition: ToolDefinition = {
   id: "data-formats-converter",
   name: "Format Converter",
-  description: "Convert between JSON, YAML, XML",
+  description: "Convert between JSON, YAML, and XML formats",
   category: "dataFormats",
-  aliases: ["convert", "converter", "transform", "json", "yaml"],
+  aliases: ["convert", "converter", "transform", "json", "yaml", "xml"],
   component: ConverterToolComponent,
   operation: (inputs) => {
     const text = String(inputs.text || "");
     const sourceFormat = String(inputs.sourceFormat || "auto");
     const targetFormat = String(inputs.targetFormat || "yaml");
     const detectedFormat = String(inputs.detectedFormat || "unknown");
+    const rootName = inputs.rootName ? String(inputs.rootName) : undefined;
+    const minify = Boolean(inputs.minify);
 
     // Return empty result if no input
     if (!text.trim()) {
@@ -108,6 +110,7 @@ const converterToolDefinition: ToolDefinition = {
       text,
       actualSource as DataFormat,
       targetFormat as DataFormat,
+      { rootName, minify },
     );
   },
 };


### PR DESCRIPTION
This PR adds bidirectional XML ↔ JSON conversion support to both the CLI and webapp, alongside UI improvements for better screen real estate utilization in the data format tools.

Key changes:
- Added XML ↔ JSON conversion functionality in core library and exposed through WASM bindings
- Extended CLI commands to support `json convert --to xml` and `xml convert --to json`
- Updated webapp converter tool to include XML format option and minify toggle
- Improved webapp layout with flexible height containers to better utilize viewport space