### PR TITLE
feat: add support to show tools based on frequency and recency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - feat: add syntax highlighter for data format tools
 - feat: add Progressive Web App (PWA) support
 - feat: add file upload and download support for data format tools
+- feat: add support to show tools based on frequency and recency
 
 ## [v1.3.0] - 2026-01-21
 

--- a/webapp/src/components/common/download-button.test.tsx
+++ b/webapp/src/components/common/download-button.test.tsx
@@ -52,8 +52,12 @@ describe("DownloadButton", () => {
     mockClick = vi.fn();
 
     // Mock URL methods globally (these don't interfere with React rendering)
-    globalThis.URL.createObjectURL = mockCreateObjectURL as any;
-    globalThis.URL.revokeObjectURL = mockRevokeObjectURL as any;
+    globalThis.URL.createObjectURL = mockCreateObjectURL as unknown as (
+      obj: Blob | MediaSource,
+    ) => string;
+    globalThis.URL.revokeObjectURL = mockRevokeObjectURL as unknown as (
+      url: string,
+    ) => void;
   });
 
   afterEach(() => {
@@ -152,10 +156,10 @@ describe("DownloadButton", () => {
 
       // Mock appendChild/removeChild now as well
       vi.spyOn(document.body, "appendChild").mockImplementation(
-        () => mockLink as any,
+        () => mockLink as unknown as HTMLAnchorElement,
       );
       vi.spyOn(document.body, "removeChild").mockImplementation(
-        () => mockLink as any,
+        () => mockLink as unknown as HTMLAnchorElement,
       );
 
       const button = screen.getByRole("button", { name: /download/i });

--- a/webapp/src/components/common/download-button.tsx
+++ b/webapp/src/components/common/download-button.tsx
@@ -63,7 +63,7 @@ export const DownloadButton: React.FC<DownloadButtonProps> = ({
         isClosable: true,
         position: "bottom-right",
       });
-    } catch (error) {
+    } catch (_error) {
       toast({
         title: "Download failed",
         description: "Failed to download file",

--- a/webapp/src/components/layout/sidebar.tsx
+++ b/webapp/src/components/layout/sidebar.tsx
@@ -143,7 +143,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   );
   const [focusedToolIndex, setFocusedToolIndex] = useState(-1);
   const sidebarRef = useRef<HTMLDivElement>(null);
-  const { favorites } = useSettings();
+  const { favorites, getFrequentlyUsedTools } = useSettings();
 
   // Create Favorites Group
   const favoritesGroup = useMemo(() => {
@@ -159,13 +159,38 @@ export const Sidebar: React.FC<SidebarProps> = ({
     };
   }, [allTools, favorites]);
 
-  // Combined groups for display, favorites first if any exist
+  // Create Frequently Used Group
+  const frequentlyUsedGroup = useMemo(() => {
+    const frequentToolIds = getFrequentlyUsedTools(5);
+    const frequentTools = frequentToolIds
+      .map((id) => allTools.find((tool) => tool.id === id))
+      .filter((tool): tool is Tool => tool !== undefined);
+
+    return {
+      name: "Frequently Used",
+      category: "frequently-used" as ToolCategory,
+      icon: "🔥",
+      description: "Your most used tools",
+      tools: frequentTools,
+    };
+  }, [allTools, getFrequentlyUsedTools]);
+
+  // Combined groups for display: favorites, frequently used, then regular groups
   const displayGroups = useMemo(() => {
+    const groups: ToolGroup[] = [];
+
     if (favoritesGroup.tools.length > 0) {
-      return [favoritesGroup, ...toolGroups];
+      groups.push(favoritesGroup);
     }
-    return toolGroups;
-  }, [favoritesGroup]);
+
+    if (frequentlyUsedGroup.tools.length > 0) {
+      groups.push(frequentlyUsedGroup);
+    }
+
+    groups.push(...toolGroups);
+
+    return groups;
+  }, [favoritesGroup, frequentlyUsedGroup]);
 
   // Memoize group start indices for keyboard navigation
   const groupStartIndices = useMemo(() => {

--- a/webapp/src/lib/utils/tool-usage.test.ts
+++ b/webapp/src/lib/utils/tool-usage.test.ts
@@ -1,0 +1,367 @@
+/**
+ * @vitest-environment node
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  calculateToolScore,
+  createInitialState,
+  deserializeState,
+  getTopToolIds,
+  serializeState,
+  sortToolsByUsage,
+  type ToolUsageData,
+  updateToolUsage,
+} from "./tool-usage";
+
+describe("tool-usage utilities", () => {
+  beforeEach(() => {
+    // Mock Date.now() for consistent testing
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("calculateToolScore", () => {
+    it("should calculate score with 70% frequency and 30% recency", () => {
+      const usage: ToolUsageData = {
+        toolId: "test-tool",
+        count: 10,
+        lastUsed: Date.now(),
+      };
+      const maxCount = 10;
+
+      const score = calculateToolScore(usage, maxCount);
+
+      expect(score).toBe(1.0);
+    });
+
+    it("should prioritize frequency over recency (70/30 split)", () => {
+      const highFreqOld: ToolUsageData = {
+        toolId: "high-freq-old",
+        count: 10,
+        lastUsed: Date.now() - 30 * 24 * 60 * 60 * 1000,
+      };
+
+      const lowFreqRecent: ToolUsageData = {
+        toolId: "low-freq-recent",
+        count: 2,
+        lastUsed: Date.now(),
+      };
+
+      const maxCount = 10;
+
+      const highFreqScore = calculateToolScore(highFreqOld, maxCount);
+      const lowFreqScore = calculateToolScore(lowFreqRecent, maxCount);
+
+      expect(highFreqScore).toBeGreaterThan(lowFreqScore);
+    });
+
+    it("should handle maxCount = 0 edge case", () => {
+      const usage: ToolUsageData = {
+        toolId: "test-tool",
+        count: 5,
+        lastUsed: Date.now(),
+      };
+
+      const score = calculateToolScore(usage, 0);
+
+      // When maxCount is 0, frequency score should be 0, only recency matters
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThanOrEqual(0.3); // Only recency component (30%)
+    });
+  });
+
+  describe("createInitialState", () => {
+    it("should create empty state", () => {
+      const state = createInitialState();
+
+      expect(state.usageMap.size).toBe(0);
+      expect(state.sortedToolIds).toEqual([]);
+      expect(state.sortedToolIds.slice(0, 5)).toEqual([]);
+    });
+  });
+
+  describe("updateToolUsage", () => {
+    it("should add new tool and precompute sorted arrays", () => {
+      const state = createInitialState();
+      const updated = updateToolUsage(state, "new-tool");
+
+      expect(updated.usageMap.size).toBe(1);
+      expect(updated.usageMap.get("new-tool")).toEqual({
+        toolId: "new-tool",
+        count: 1,
+        lastUsed: Date.now(),
+      });
+
+      // Precomputed arrays should be updated
+      expect(updated.sortedToolIds).toEqual(["new-tool"]);
+      expect(updated.sortedToolIds.slice(0, 5)).toEqual(["new-tool"]);
+    });
+
+    it("should increment count and recompute sorted arrays", () => {
+      let state = createInitialState();
+      state = updateToolUsage(state, "tool1");
+      state = updateToolUsage(state, "tool2");
+      state = updateToolUsage(state, "tool1"); // Use tool1 again
+
+      expect(state.usageMap.get("tool1")?.count).toBe(2);
+      expect(state.usageMap.get("tool2")?.count).toBe(1);
+
+      // tool1 should be first (higher count)
+      expect(state.sortedToolIds[0]).toBe("tool1");
+      expect(state.sortedToolIds.slice(0, 5)[0]).toBe("tool1");
+    });
+
+    it("should track many tools and maintain sorted order", () => {
+      let state = createInitialState();
+
+      // Add 10 tools with different usage counts
+      for (let i = 1; i <= 10; i++) {
+        for (let j = 0; j < i; j++) {
+          state = updateToolUsage(state, `tool${i}`);
+        }
+      }
+
+      expect(state.usageMap.size).toBe(10);
+      // tool10 should be first (used 10 times)
+      expect(state.sortedToolIds[0]).toBe("tool10");
+      // tool1 should be last (used 1 time)
+      expect(state.sortedToolIds[9]).toBe("tool1");
+
+      // Top 5 should be tool10, tool9, tool8, tool7, tool6
+      expect(state.sortedToolIds.slice(0, 5)).toEqual([
+        "tool10",
+        "tool9",
+        "tool8",
+        "tool7",
+        "tool6",
+      ]);
+    });
+
+    it("should not mutate original state", () => {
+      const state = createInitialState();
+      const originalSize = state.usageMap.size;
+
+      updateToolUsage(state, "new-tool");
+
+      expect(state.usageMap.size).toBe(originalSize);
+    });
+  });
+
+  describe("getTopToolIds", () => {
+    it("should return precomputed top 5 for default limit", () => {
+      let state = createInitialState();
+
+      for (let i = 1; i <= 10; i++) {
+        for (let j = 0; j < i; j++) {
+          state = updateToolUsage(state, `tool${i}`);
+        }
+      }
+
+      const result = getTopToolIds(state);
+
+      // Should slice the precomputed array
+      expect(result).toEqual(state.sortedToolIds.slice(0, 5));
+      expect(result).toHaveLength(5);
+    });
+
+    it("should return empty array for empty state", () => {
+      const state = createInitialState();
+      const result = getTopToolIds(state);
+
+      expect(result).toEqual([]);
+    });
+
+    it("should handle custom limits", () => {
+      let state = createInitialState();
+
+      for (let i = 1; i <= 10; i++) {
+        state = updateToolUsage(state, `tool${i}`);
+      }
+
+      const result = getTopToolIds(state, 3);
+
+      expect(result).toHaveLength(3);
+    });
+  });
+
+  describe("sortToolsByUsage", () => {
+    interface TestTool {
+      id: string;
+      name: string;
+    }
+
+    it("should return original array if no usage data", () => {
+      const tools: TestTool[] = [
+        { id: "tool1", name: "Tool 1" },
+        { id: "tool2", name: "Tool 2" },
+      ];
+      const state = createInitialState();
+
+      const result = sortToolsByUsage(tools, state);
+
+      expect(result).toEqual(tools);
+    });
+
+    it("should sort tools based on precomputed order", () => {
+      const tools: TestTool[] = [
+        { id: "tool1", name: "Tool 1" },
+        { id: "tool2", name: "Tool 2" },
+        { id: "tool3", name: "Tool 3" },
+      ];
+
+      let state = createInitialState();
+      // Use tools in different amounts
+      state = updateToolUsage(state, "tool2"); // 1
+      state = updateToolUsage(state, "tool2"); // 2
+      state = updateToolUsage(state, "tool1"); // 1
+      state = updateToolUsage(state, "tool3"); // 1
+      state = updateToolUsage(state, "tool3"); // 2
+      state = updateToolUsage(state, "tool3"); // 3
+
+      const result = sortToolsByUsage(tools, state);
+
+      // tool3 (3), tool2 (2), tool1 (1)
+      expect(result.map((t) => t.id)).toEqual(["tool3", "tool2", "tool1"]);
+    });
+
+    it("should place untracked tools at the end", () => {
+      const tools: TestTool[] = [
+        { id: "tracked1", name: "Tracked 1" },
+        { id: "untracked", name: "Untracked" },
+        { id: "tracked2", name: "Tracked 2" },
+      ];
+
+      let state = createInitialState();
+      state = updateToolUsage(state, "tracked1");
+      state = updateToolUsage(state, "tracked2");
+      state = updateToolUsage(state, "tracked2");
+
+      const result = sortToolsByUsage(tools, state);
+
+      expect(result.map((t) => t.id)).toEqual([
+        "tracked2",
+        "tracked1",
+        "untracked",
+      ]);
+    });
+
+    it("should not mutate original array", () => {
+      const tools: TestTool[] = [
+        { id: "tool1", name: "Tool 1" },
+        { id: "tool2", name: "Tool 2" },
+      ];
+
+      let state = createInitialState();
+      state = updateToolUsage(state, "tool2");
+
+      const original = [...tools];
+      sortToolsByUsage(tools, state);
+
+      expect(tools).toEqual(original);
+    });
+
+    it("should handle when sortedToolIds contains tools not in input array", () => {
+      const tools: TestTool[] = [
+        { id: "tool1", name: "Tool 1" },
+        { id: "tool3", name: "Tool 3" },
+      ];
+
+      let state = createInitialState();
+      state = updateToolUsage(state, "tool1");
+      state = updateToolUsage(state, "tool2"); // tool2 not in tools array
+      state = updateToolUsage(state, "tool3");
+
+      const result = sortToolsByUsage(tools, state);
+
+      // Should only include tools that exist in input array, in usage order
+      // tool1 used once, tool3 used once, but tool1 was used first
+      expect(result.map((t) => t.id)).toEqual(["tool1", "tool3"]);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("serializeState and deserializeState", () => {
+    it("should serialize and deserialize state correctly", () => {
+      let state = createInitialState();
+      state = updateToolUsage(state, "tool1");
+      state = updateToolUsage(state, "tool2");
+      state = updateToolUsage(state, "tool1");
+
+      const serialized = serializeState(state);
+      const deserialized = deserializeState(serialized);
+
+      expect(deserialized.usageMap.size).toBe(state.usageMap.size);
+      expect(deserialized.sortedToolIds).toEqual(state.sortedToolIds);
+      expect(deserialized.sortedToolIds.slice(0, 5)).toEqual(
+        state.sortedToolIds.slice(0, 5),
+      );
+      expect(deserialized.usageMap.get("tool1")).toEqual(
+        state.usageMap.get("tool1"),
+      );
+    });
+
+    it("should handle empty state", () => {
+      const state = createInitialState();
+      const serialized = serializeState(state);
+      const deserialized = deserializeState(serialized);
+
+      expect(deserialized.usageMap.size).toBe(0);
+      expect(deserialized.sortedToolIds).toEqual([]);
+      expect(deserialized.sortedToolIds.slice(0, 5)).toEqual([]);
+    });
+
+    it("should handle invalid JSON gracefully", () => {
+      const deserialized = deserializeState("invalid json");
+
+      expect(deserialized.usageMap.size).toBe(0);
+      expect(deserialized.sortedToolIds).toEqual([]);
+      expect(deserialized.sortedToolIds.slice(0, 5)).toEqual([]);
+    });
+
+    it("should preserve precomputed data across serialization", () => {
+      let state = createInitialState();
+
+      for (let i = 1; i <= 10; i++) {
+        for (let j = 0; j < i; j++) {
+          state = updateToolUsage(state, `tool${i}`);
+        }
+      }
+
+      const serialized = serializeState(state);
+      const deserialized = deserializeState(serialized);
+
+      // Precomputed arrays should be preserved
+      expect(deserialized.sortedToolIds).toEqual(state.sortedToolIds);
+      expect(deserialized.sortedToolIds.slice(0, 5)).toEqual(
+        state.sortedToolIds.slice(0, 5),
+      );
+      expect(deserialized.sortedToolIds.slice(0, 5)).toHaveLength(5);
+    });
+
+    it("should handle missing usage field in JSON", () => {
+      const json = JSON.stringify({ sorted: ["tool1", "tool2"] });
+      const deserialized = deserializeState(json);
+
+      expect(deserialized.usageMap.size).toBe(0);
+      expect(deserialized.sortedToolIds).toEqual(["tool1", "tool2"]);
+    });
+
+    it("should handle missing sorted field in JSON", () => {
+      const json = JSON.stringify({
+        usage: [
+          { toolId: "tool1", count: 5, lastUsed: Date.now() },
+          { toolId: "tool2", count: 3, lastUsed: Date.now() },
+        ],
+      });
+      const deserialized = deserializeState(json);
+
+      expect(deserialized.usageMap.size).toBe(2);
+      expect(deserialized.sortedToolIds).toEqual([]);
+    });
+  });
+});

--- a/webapp/src/lib/utils/tool-usage.ts
+++ b/webapp/src/lib/utils/tool-usage.ts
@@ -1,0 +1,179 @@
+export interface ToolUsageData {
+  toolId: string;
+  count: number;
+  lastUsed: number;
+}
+
+/**
+ * Precomputed usage state for O(1) reads
+ * All heavy computation is done during writes
+ */
+export interface ToolUsageState {
+  // Raw usage data
+  usageMap: Map<string, ToolUsageData>;
+  // Precomputed: sorted array of all tool IDs by score (highest first)
+  sortedToolIds: string[];
+}
+
+/**
+ * Calculate usage score for a tool based on frequency and recency
+ * @param usage - Tool usage data containing count and lastUsed timestamp
+ * @param maxCount - Maximum count among all tools (for normalization)
+ * @returns Score between 0 and 1 (70% frequency, 30% recency)
+ */
+export const calculateToolScore = (
+  usage: ToolUsageData,
+  maxCount: number,
+): number => {
+  const frequencyScore = maxCount > 0 ? usage.count / maxCount : 0;
+  const daysSinceLastUse =
+    (Date.now() - usage.lastUsed) / (1000 * 60 * 60 * 24);
+  const recencyScore = 1 / (1 + daysSinceLastUse);
+  return frequencyScore * 0.7 + recencyScore * 0.3;
+};
+
+/**
+ * Compute sorted tool IDs from usage map
+ * This is the heavy lifting done during writes
+ */
+const computeSortedToolIds = (
+  usageMap: Map<string, ToolUsageData>,
+): string[] => {
+  if (usageMap.size === 0) return [];
+
+  const usageArray = Array.from(usageMap.values());
+  const maxCount = Math.max(...usageArray.map((u) => u.count));
+
+  return usageArray
+    .map((usage) => ({
+      toolId: usage.toolId,
+      score: calculateToolScore(usage, maxCount),
+    }))
+    .sort((a, b) => b.score - a.score)
+    .map((item) => item.toolId);
+};
+
+/**
+ * Update tool usage data with a new usage event
+ * WRITE PATH: Does all heavy computation here for O(1) reads
+ * @param currentState - Current usage state
+ * @param toolId - ID of the tool being used
+ * @returns New state with precomputed sorted arrays
+ */
+export const updateToolUsage = (
+  currentState: ToolUsageState,
+  toolId: string,
+): ToolUsageState => {
+  // Update the usage map
+  const newMap = new Map(currentState.usageMap);
+  const existing = newMap.get(toolId);
+
+  if (existing) {
+    newMap.set(toolId, {
+      toolId,
+      count: existing.count + 1,
+      lastUsed: Date.now(),
+    });
+  } else {
+    newMap.set(toolId, {
+      toolId,
+      count: 1,
+      lastUsed: Date.now(),
+    });
+  }
+
+  // HEAVY LIFTING: Precompute sorted array (done on write)
+  const sortedToolIds = computeSortedToolIds(newMap);
+
+  return {
+    usageMap: newMap,
+    sortedToolIds,
+  };
+};
+
+/**
+ * Get the top N frequently used tool IDs
+ * @param state - Precomputed usage state
+ * @param limit - Maximum number of tools to return (default: 5)
+ * @returns Array of tool IDs sorted by score (highest first)
+ */
+export const getTopToolIds = (state: ToolUsageState, limit = 5): string[] => {
+  // O(1) - just slice the precomputed array
+  return state.sortedToolIds.slice(0, limit);
+};
+
+/**
+ * Sort tools by usage score, placing untracked tools at the end
+ * @param tools - Array of tools to sort
+ * @param state - Precomputed usage state
+ * @returns Sorted array of tools
+ */
+export const sortToolsByUsage = <T extends { id: string }>(
+  tools: T[],
+  state: ToolUsageState,
+): T[] => {
+  if (state.sortedToolIds.length === 0) return tools;
+
+  // Create lookup map: toolId -> tool object
+  const toolMap = new Map<string, T>();
+  const untrackedTools: T[] = [];
+
+  for (const tool of tools) {
+    if (state.sortedToolIds.includes(tool.id)) {
+      toolMap.set(tool.id, tool);
+    } else {
+      untrackedTools.push(tool);
+    }
+  }
+
+  // Build result array from precomputed order
+  const result: T[] = [];
+  for (const toolId of state.sortedToolIds) {
+    const tool = toolMap.get(toolId);
+    if (tool) {
+      result.push(tool);
+    }
+  }
+
+  // Append untracked tools at the end
+  return [...result, ...untrackedTools];
+};
+
+/**
+ * Create initial empty state
+ */
+export const createInitialState = (): ToolUsageState => ({
+  usageMap: new Map(),
+  sortedToolIds: [],
+});
+
+/**
+ * Serialize state for localStorage
+ */
+export const serializeState = (state: ToolUsageState): string => {
+  return JSON.stringify({
+    usage: Array.from(state.usageMap.values()),
+    sorted: state.sortedToolIds,
+  });
+};
+
+/**
+ * Deserialize state from localStorage
+ */
+export const deserializeState = (json: string): ToolUsageState => {
+  try {
+    const data = JSON.parse(json);
+    const usageMap = new Map<string, ToolUsageData>();
+
+    (data.usage || []).forEach((item: ToolUsageData) => {
+      usageMap.set(item.toolId, item);
+    });
+
+    return {
+      usageMap,
+      sortedToolIds: data.sorted || [],
+    };
+  } catch {
+    return createInitialState();
+  }
+};

--- a/webapp/src/pages/home.tsx
+++ b/webapp/src/pages/home.tsx
@@ -14,7 +14,7 @@ import {
   VStack,
 } from "@chakra-ui/react";
 import type React from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { BsPinAngle, BsPinFill, BsStar, BsStarFill } from "react-icons/bs";
 import { useNavigate } from "react-router-dom";
 import { CommandPalette, HelpModal } from "../components/common";
@@ -47,6 +47,7 @@ export const Home: React.FC = () => {
   } = useDisclosure();
 
   const handleToolClick = (toolId: string) => {
+    recordToolUsage(toolId);
     navigate(`/tool/${toolId}`);
   };
 
@@ -54,6 +55,7 @@ export const Home: React.FC = () => {
     setSelectedTool(tool);
     navigate(`/tool/${tool.id}`);
     onCommandPaletteClose();
+    recordToolUsage(tool.id);
     // Auto-close sidebar after selection (especially useful on mobile)
     if (window.innerWidth < 768 && isSidebarOpen) {
       onSidebarToggle();
@@ -69,11 +71,17 @@ export const Home: React.FC = () => {
     togglePinnedTool,
     showFavoritesOnly,
     toggleShowFavoritesOnly,
+    recordToolUsage,
+    getSortedToolsByUsage,
   } = useSettings();
 
-  const displayedTools = showFavoritesOnly
-    ? allTools.filter((tool) => isFavorite(tool.id))
-    : allTools;
+  const displayedTools = useMemo(() => {
+    const filtered = showFavoritesOnly
+      ? allTools.filter((tool) => isFavorite(tool.id))
+      : allTools;
+
+    return getSortedToolsByUsage(filtered);
+  }, [showFavoritesOnly, allTools, isFavorite, getSortedToolsByUsage]);
 
   return (
     <Layout


### PR DESCRIPTION
- This PR adds support to display tools on the homepage and sidebar based on the frequency and recency of the tool usage.
- 70% weightage is given to frequency and 30% to recency.